### PR TITLE
Use a file picker widget for setting logos and backgrounds that allows clearing the setting

### DIFF
--- a/usr/lib/lightdm-settings/lightdm-settings
+++ b/usr/lib/lightdm-settings/lightdm-settings
@@ -107,9 +107,9 @@ class Application(Gtk.Application):
             pass
         section.add_row(SettingsRow(Gtk.Label(_("Show hostname")), SettingsSwitch(keyfile, settings, "show-hostname")))
 
-        row = section.add_row(SettingsRow(Gtk.Label(_("Logo")), SettingsFileChooser(keyfile, settings, "logo")))
-        row = section.add_row(SettingsRow(Gtk.Label(_("Background logo")), SettingsFileChooser(keyfile, settings, "background-logo")))
-        row = section.add_row(SettingsRow(Gtk.Label(_("Background")), SettingsFileChooser(keyfile, settings, "background")))
+        row = section.add_row(SettingsRow(Gtk.Label(_("Logo")), SettingsPictureChooser(keyfile, settings, "logo")))
+        row = section.add_row(SettingsRow(Gtk.Label(_("Background logo")), SettingsPictureChooser(keyfile, settings, "background-logo")))
+        row = section.add_row(SettingsRow(Gtk.Label(_("Background")), SettingsPictureChooser(keyfile, settings, "background")))
 
         row = section.add_row(SettingsRow(Gtk.Label(_("Background color")), SettingsColorChooser(keyfile, settings, "background-color")))
 


### PR DESCRIPTION
Also, add a preview to the picker dialog and a shortcut to the system backgrounds folder.