### PR TITLE
pass env vars to allow app run as root to use them

### DIFF
--- a/usr/bin/lightdm-settings
+++ b/usr/bin/lightdm-settings
@@ -2,6 +2,8 @@
 
 import xapp.os
 import gettext
+import locale
+import os
 
 DOMAIN = "lightdm-settings"
 PATH = "/usr/share/locale"
@@ -10,6 +12,13 @@ gettext.install(DOMAIN, PATH)
 icon = "preferences-system-login.png"
 message = _("Login Window")
 
-# We disable pkexec here because it fails to apply the correct locale
-# The app should show in the user's locale, not the system one.
-xapp.os.run_with_admin_privs("/usr/lib/lightdm-settings/lightdm-settings", message=message, icon=icon, support_pkexec=False)
+# We add the current locale and desktop since for some sessions
+# (e.g. gnome-session) pkexec does not pass them - i.e. need to apply
+# the user's locale, not the system one (assuming there is one).
+loc = locale.getdefaultlocale()
+locstr = loc[0] + "." + loc[1]
+xapp.os.run_with_admin_privs("/usr/lib/lightdm-settings/lightdm-settings " +
+    locstr + " " + os.environ["XDG_CURRENT_DESKTOP"],
+    message=message,
+    icon=icon,
+    support_pkexec=True)

--- a/usr/lib/lightdm-settings/lightdm-settings
+++ b/usr/lib/lightdm-settings/lightdm-settings
@@ -6,6 +6,7 @@ import gi
 import gettext
 import sys
 import glob
+import locale
 from SettingsWidgets import *
 
 gi.require_version('Gtk', '3.0')
@@ -17,8 +18,6 @@ except:
     pass
 
 setproctitle.setproctitle("lightdm-settings")
-
-gettext.install("lightdm-settings", "/usr/share/locale")
 
 CONF_PATH = "/etc/lightdm/slick-greeter.conf"
 LIGHTDM_CONF_PATH = "/etc/lightdm/lightdm.conf"
@@ -239,5 +238,10 @@ class Application(Gtk.Application):
         return (value)
 
 if __name__ == "__main__":
+    os.environ["LANG"] = sys.argv[1]
+    os.environ["LANGUAGE"] = sys.argv[1]
+    os.environ['XDG_CURRENT_DESKTOP'] = sys.argv[2]
+    gettext.install("lightdm-settings", "/usr/share/locale")
+
     app = Application()
     app.run(None)


### PR DESCRIPTION
As discussed in #9 

For sessions such as gnome-session, when run as root, a pkexec does not pass the users locale

We need these env-vars to allow a) the current desktop name for headerbars to display correctly and b) for localised strings to display correctly.