### PR TITLE
Fix IndexError when no GTK themes are installed

### DIFF
--- a/usr/lib/lightdm-settings/SettingsWidgets.py
+++ b/usr/lib/lightdm-settings/SettingsWidgets.py
@@ -296,7 +296,7 @@ class SettingsCombo(Gtk.ComboBox):
         self.set_valign(Gtk.Align.CENTER)
 
         # assume all keys are the same type (mixing types is going to cause an error somewhere)
-        var_type = type(options[0][0])
+        var_type = type(options[0][0]) if options else None
         self.model = Gtk.ListStore(var_type, str)
         self.valtype = valtype
         self.option_map = {}


### PR DESCRIPTION
When no GTK themes are installed on the system, an IndexError is raised in the SettingsCombo initializer when attempting to check the key type using the (nonexistent) first theme in the directory (Issue #27). I've added a fallback value of `None`, which allows the program to run as expected.