### PR TITLE
Fix conf location

### DIFF
--- a/usr/lib/lightdm-settings/SettingsWidgets.py
+++ b/usr/lib/lightdm-settings/SettingsWidgets.py
@@ -5,7 +5,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gio, Gdk, GLib, GdkPixbuf
 
-CONF_PATH = "/etc/lightdm/slick-greeter.conf"
+CONF_PATH = "/etc/lightdm/lightdm.conf.d/slick-greeter.conf"
 GROUP_NAME = "Greeter"
 
 LIGHTDM_CONF_PATH = "/etc/lightdm/lightdm.conf"

--- a/usr/lib/lightdm-settings/lightdm-settings
+++ b/usr/lib/lightdm-settings/lightdm-settings
@@ -16,7 +16,7 @@ setproctitle.setproctitle("lightdm-settings")
 
 gettext.install("lightdm-settings", "/usr/share/locale")
 
-CONF_PATH = "/etc/lightdm/slick-greeter.conf"
+CONF_PATH = "/etc/lightdm/lightdm.conf.d/slick-greeter.conf"
 LIGHTDM_CONF_PATH = "/etc/lightdm/lightdm.conf"
 LIGHTDM_GROUP_NAMES = ["SeatDefaults", "Seat:*"]
 


### PR DESCRIPTION
Lightdm ignores slick-greeter.conf in it's current location

Part of https://github.com/linuxmint/slick-greeter/pull/254